### PR TITLE
FixtureLifeCycle

### DIFF
--- a/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\common.props" />
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit.Tests</AssemblyTitle>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
  
   <ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
   </ItemGroup>

--- a/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
+++ b/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
@@ -9,8 +9,9 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit.Tests
 {
-    [TestFixture]
-    public class AssertionsTests
+    //[TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class AssertionsTests : TestKit
     {
         private readonly NUnitAssertions _assertions;
 

--- a/src/Akka.TestKit.NUnit.Tests/TestKitTestFixtureTest.cs
+++ b/src/Akka.TestKit.NUnit.Tests/TestKitTestFixtureTest.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit.Tests
 {
-    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
     public class TestKitTestFixtureTest : TestKit
     {
         [Test]

--- a/src/Akka.TestKit.NUnit.Tests/TestKitTests.cs
+++ b/src/Akka.TestKit.NUnit.Tests/TestKitTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit.Tests
 {
-    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
     public class TestKitTests : TestKit
     {
         [TearDown]

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -3,12 +3,12 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
+    <PackageReference Include="Akka.TestKit" Version="1.4.39" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
   </ItemGroup>
 

--- a/src/Akka.TestKit.NUnit/TestKit.cs
+++ b/src/Akka.TestKit.NUnit/TestKit.cs
@@ -15,6 +15,9 @@ namespace Akka.TestKit.NUnit
     /// <summary>
     /// TestKit for NUnit.
     /// </summary>
+    /// 
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class TestKit : TestKitBase, IDisposable
     {
         private static readonly NUnitAssertions _assertions = new NUnitAssertions();

--- a/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
+++ b/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\common.props" />
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit3.Tests</AssemblyTitle>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
  
   <ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
   </ItemGroup>

--- a/src/Akka.TestKit.NUnit3.Tests/AssertionsTests.cs
+++ b/src/Akka.TestKit.NUnit3.Tests/AssertionsTests.cs
@@ -9,8 +9,9 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit3.Tests
 {
-    [TestFixture]
-    public class AssertionsTests
+    //[TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class AssertionsTests : TestKit
     {
         private readonly NUnitAssertions _assertions;
 

--- a/src/Akka.TestKit.NUnit3.Tests/TestKitTestFixtureTest.cs
+++ b/src/Akka.TestKit.NUnit3.Tests/TestKitTestFixtureTest.cs
@@ -11,7 +11,8 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit3.Tests
 {
-    [TestFixture]
+    //[TestFixture]
+    [Parallelizable(ParallelScope.All)]
     public class TestKitTestFixtureTest : TestKit
     {
         [Test]

--- a/src/Akka.TestKit.NUnit3.Tests/TestKitTests.cs
+++ b/src/Akka.TestKit.NUnit3.Tests/TestKitTests.cs
@@ -10,7 +10,8 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit3.Tests
 {
-    [TestFixture]
+    //[TestFixture]
+    [Parallelizable(ParallelScope.All)]
     public class TestKitTests : TestKit
     {
         [TearDown]

--- a/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
+++ b/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
@@ -3,12 +3,12 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
+    <PackageReference Include="Akka.TestKit" Version="1.4.39" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
   </ItemGroup>
 

--- a/src/Akka.TestKit.NUnit3/TestKit.cs
+++ b/src/Akka.TestKit.NUnit3/TestKit.cs
@@ -15,6 +15,9 @@ namespace Akka.TestKit.NUnit3
     /// <summary>
     /// TestKit for NUnit.
     /// </summary>
+    /// 
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class TestKit : TestKitBase, IDisposable
     {
         private static readonly NUnitAssertions _assertions = new NUnitAssertions();

--- a/src/common.props
+++ b/src/common.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2013-2018</Copyright>
+    <Copyright>Copyright © 2013-2022</Copyright>
     <Authors>Akka.NET Contrib</Authors>
     <Description>TestKit for writing tests for Akka.NET using NUnit.</Description>
-    <VersionPrefix>1.3.8</VersionPrefix>
+    <VersionPrefix>1.4.39</VersionPrefix>
     <PackageReleaseNotes>Support for Akka 1.3.8
-Support for NUnit 3.10.1</PackageReleaseNotes>
+Support for NUnit 3.13.3</PackageReleaseNotes>
     <PackageTags>akka;actors;actor model;Akka;concurrency;testkit;nunit</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
@@ -14,8 +14,8 @@ Support for NUnit 3.10.1</PackageReleaseNotes>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <NUnitVersion>3.10.1</NUnitVersion>
-    <NUnitAdapterVersion>3.10.0</NUnitAdapterVersion>
-    <AkkaTestKitVersion>1.3.8</AkkaTestKitVersion>
+    <NUnitVersion>3.13.3</NUnitVersion>
+    <NUnitAdapterVersion>4.2.1</NUnitAdapterVersion>
+    <AkkaTestKitVersion>1.4.39</AkkaTestKitVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Changes

@mchandschuh

nunit 3.13 added [FixtureLifeCycle(LifeCycle.InstancePerTestCase)] which should obviate the need for code bombing when an ActorSystem is provided to the TestKit constructor.

Describe the bug

    Unable to specify ActorSystem in TestKit constructor

To Reproduce

    Try instantiating TestKit with an ActorSystem

See: https://github.com/akkadotnet/akka.net/pull/1092