### PR TITLE
.NET Standard 2.0

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -40,7 +40,7 @@ partial class Build : NukeBuild
     ///   - Microsoft VisualStudio     https://nuke.build/visualstudio
     ///   - Microsoft VSCode           https://nuke.build/vscode
 
-    public static int Main() => Execute<Build>(x => x.Install);
+    public static int Main() => Execute<Build>(x => x.RunTests);
 
     [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
     readonly Configuration Configuration = Configuration.Release;

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="1.4.39" />
+    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
   </ItemGroup>
 

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 

--- a/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
+++ b/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 

--- a/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
+++ b/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="1.4.39" />
+    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
## Changes

Currently <TargetFrameworks>net6.0</TargetFrameworks> - need to update this to be netstandard2.0 for any NuGet packages. https://github.com/akkadotnet/Akka.TestKit.NUnit/issues/48