### PR TITLE
Fix/44 `ActorSystem` lifecycle

### DIFF
--- a/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
+++ b/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit.Tests
 {
-    //[TestFixture]
     [Parallelizable(ParallelScope.All)]
     public class AssertionsTests : TestKit
     {

--- a/src/Akka.TestKit.NUnit.Tests/Bugfix44Spec.cs
+++ b/src/Akka.TestKit.NUnit.Tests/Bugfix44Spec.cs
@@ -1,0 +1,27 @@
+﻿using Akka.Actor;
+using NUnit.Framework;
+
+namespace Akka.TestKit.NUnit.Tests;
+
+[TestFixture]
+public class Bugfix44Spec : TestKit
+{
+    // need to have the DefaultConfig for the TestKit with this ActorSystem
+    public Bugfix44Spec() : base(ActorSystem.Create("Foo", TestKit.DefaultConfig))
+    {
+        
+    }
+    
+    [Test]
+    public void Should_use_provided_ActorSystem()
+    {
+        Assertions.AssertEqual("Foo",Sys.Name);
+    }
+    
+    [Test]
+    public void Should_use_provided_ActorSystem_again()
+    {
+        // Technically this will be a second, different ActorSystem but the names should be the same
+        Assertions.AssertEqual("Foo",Sys.Name);
+    }
+}

--- a/src/Akka.TestKit.NUnit.Tests/Bugfix44Spec.cs
+++ b/src/Akka.TestKit.NUnit.Tests/Bugfix44Spec.cs
@@ -12,16 +12,20 @@ public class Bugfix44Spec : TestKit
         
     }
     
-    [Test]
+    private static ActorSystem _previousSystem;
+    
+    [Test, Order(1)]
     public void Should_use_provided_ActorSystem()
     {
+        _previousSystem = Sys;
         Assertions.AssertEqual("Foo",Sys.Name);
     }
     
-    [Test]
+    [Test, Order(2)]
     public void Should_use_provided_ActorSystem_again()
     {
         // Technically this will be a second, different ActorSystem but the names should be the same
         Assertions.AssertEqual("Foo",Sys.Name);
+        Assertions.AssertFalse(_previousSystem.Equals(Sys));
     }
 }

--- a/src/Akka.TestKit.NUnit/TestKit.cs
+++ b/src/Akka.TestKit.NUnit/TestKit.cs
@@ -35,8 +35,6 @@ namespace Akka.TestKit.NUnit
         public TestKit(ActorSystem system = null)
             : base(_assertions, system)
         {
-            if(system != null)
-                throw new NotSupportedException("Due to the way NUnit works, providing an ActorSystem is not supported.  For further details please see https://github.com/akkadotnet/akka.net/pull/1092");
         }
 
         /// <summary>

--- a/src/Akka.TestKit.NUnit/TestKit.cs
+++ b/src/Akka.TestKit.NUnit/TestKit.cs
@@ -23,7 +23,6 @@ namespace Akka.TestKit.NUnit
         private static readonly NUnitAssertions _assertions = new NUnitAssertions();
         private readonly Config _config;
         private readonly string _actorSystemName;
-        private bool _isFirstRun = true;
         private bool _isDisposed; //Automatically initialized to false;
 
         /// <summary>
@@ -66,18 +65,7 @@ namespace Akka.TestKit.NUnit
         public new static Config FullDebugConfig { get { return TestKitBase.FullDebugConfig; } }
 
         protected static NUnitAssertions Assertions { get { return _assertions; } }
-
-        /// <summary>
-        /// This method is called before each test run, it initializes the test including
-        /// creating and setting up the ActorSystem.
-        /// </summary>
-        [SetUp]
-        public void InitializeActorSystemOnSetUp()
-        {
-            if (!_isFirstRun)
-                InitializeTest(null, _config, _actorSystemName, null);
-        }
-
+        
         /// <summary>
         /// This method is called after each test finishes, which calls
         /// into the AfterAll method.
@@ -85,7 +73,6 @@ namespace Akka.TestKit.NUnit
         [TearDown]
         public void ShutDownActorSystemOnTearDown()
         {
-            _isFirstRun = false;
             AfterAll();
         }
 

--- a/src/Akka.TestKit.NUnit3.Tests/AssertionsTests.cs
+++ b/src/Akka.TestKit.NUnit3.Tests/AssertionsTests.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit3.Tests
 {
-    //[TestFixture]
     [Parallelizable(ParallelScope.All)]
     public class AssertionsTests : TestKit
     {

--- a/src/Akka.TestKit.NUnit3.Tests/Bugfix44Spec.cs
+++ b/src/Akka.TestKit.NUnit3.Tests/Bugfix44Spec.cs
@@ -1,0 +1,27 @@
+﻿using Akka.Actor;
+using NUnit.Framework;
+
+namespace Akka.TestKit.NUnit3.Tests;
+
+[TestFixture]
+public class Bugfix44Spec : TestKit
+{
+    // need to have the DefaultConfig for the TestKit with this ActorSystem
+    public Bugfix44Spec() : base(ActorSystem.Create("Foo", TestKit.DefaultConfig))
+    {
+        
+    }
+    
+    [Test]
+    public void Should_use_provided_ActorSystem()
+    {
+        Assertions.AssertEqual("Foo",Sys.Name);
+    }
+    
+    [Test]
+    public void Should_use_provided_ActorSystem_again()
+    {
+        // Technically this will be a second, different ActorSystem but the names should be the same
+        Assertions.AssertEqual("Foo",Sys.Name);
+    }
+}

--- a/src/Akka.TestKit.NUnit3.Tests/TestKitTestFixtureTest.cs
+++ b/src/Akka.TestKit.NUnit3.Tests/TestKitTestFixtureTest.cs
@@ -11,7 +11,6 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit3.Tests
 {
-    //[TestFixture]
     [Parallelizable(ParallelScope.All)]
     public class TestKitTestFixtureTest : TestKit
     {

--- a/src/Akka.TestKit.NUnit3.Tests/TestKitTests.cs
+++ b/src/Akka.TestKit.NUnit3.Tests/TestKitTests.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit3.Tests
 {
-    //[TestFixture]
     [Parallelizable(ParallelScope.All)]
     public class TestKitTests : TestKit
     {

--- a/src/Akka.TestKit.NUnit3/TestKit.cs
+++ b/src/Akka.TestKit.NUnit3/TestKit.cs
@@ -35,8 +35,6 @@ namespace Akka.TestKit.NUnit3
         public TestKit(ActorSystem system = null)
             : base(_assertions, system)
         {
-            if(system != null)
-                throw new NotSupportedException("Due to the way NUnit works, providing an ActorSystem is not supported.  For further details please see https://github.com/akkadotnet/akka.net/pull/1092");
         }
 
         /// <summary>

--- a/src/Akka.TestKit.NUnit3/TestKit.cs
+++ b/src/Akka.TestKit.NUnit3/TestKit.cs
@@ -23,7 +23,6 @@ namespace Akka.TestKit.NUnit3
         private static readonly NUnitAssertions _assertions = new NUnitAssertions();
         private readonly Config _config;
         private readonly string _actorSystemName;
-        private bool _isFirstRun = true;
         private bool _isDisposed; //Automatically initialized to false;
 
         /// <summary>
@@ -68,24 +67,12 @@ namespace Akka.TestKit.NUnit3
         protected static NUnitAssertions Assertions { get { return _assertions; } }
 
         /// <summary>
-        /// This method is called before each test run, it initializes the test including
-        /// creating and setting up the ActorSystem.
-        /// </summary>
-        [SetUp]
-        public void InitializeActorSystemOnSetUp()
-        {
-            if (!_isFirstRun)
-                InitializeTest(null, _config, _actorSystemName, null);
-        }
-
-        /// <summary>
         /// This method is called after each test finishes, which calls
         /// into the AfterAll method.
         /// </summary>
         [TearDown]
         public void ShutDownActorSystemOnTearDown()
         {
-            _isFirstRun = false;
             AfterAll();
         }
 


### PR DESCRIPTION
Fixes #44

## Changes

Removed all of the old hacks we needed to do in order to make the NUnit testkit behave like the xUnit test kit (to provide isolated `ActorSystem`s on each test.)

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

cc @mchandschuh