### PR TITLE
added v1.4.39 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
-## [1.3.8] / 14 July 2018
- - Support for Akka 1.3.8
- - Support for NUnit 3.10.1
+## [1.4.39] / July 22 2022
+ - Support for Akka 1.4.39
+ - Support for NUnit 3.13.3
+ - Now targets `netstandard2.0`
+ - All `TestKit` classes now implement `[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]` which guarantees a unique `ActorSystem` instance per-run. All previous TestKit hacks needed to support this are now removed. See https://github.com/akkadotnet/Akka.TestKit.NUnit/issues/44 for details.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,9 +3,11 @@
 		<Copyright>Copyright © 2013-2022</Copyright>
 		<Authors>Akka.NET Contrib</Authors>
 		<Description>TestKit for writing tests for Akka.NET using NUnit.</Description>
-		<VersionPrefix>1.3.8</VersionPrefix>
-		<PackageReleaseNotes> • Support for Akka 1.3.8
- • Support for NUnit 3.10.1</PackageReleaseNotes>
+		<VersionPrefix>1.4.39</VersionPrefix>
+		<PackageReleaseNotes> • Support for Akka 1.4.39
+ • Support for NUnit 3.13.3
+ • Now targets netstandard2.0
+ • All TestKit classes now implement [FixtureLifeCycle(LifeCycle.InstancePerTestCase)] which guarantees a unique ActorSystem instance per-run. All previous TestKit hacks needed to support this are now removed. See https://github.com/akkadotnet/Akka.TestKit.NUnit/issues/44 for details.</PackageReleaseNotes>
 		<PackageTags>akka;actors;actor model;Akka;concurrency;testkit;nunit</PackageTags>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>


### PR DESCRIPTION
## [1.4.39] / July 22 2022
 - Support for Akka 1.4.39
 - Support for NUnit 3.13.3
 - Now targets `netstandard2.0`
 - All `TestKit` classes now implement `[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]` which guarantees a unique `ActorSystem` instance per-run. All previous TestKit hacks needed to support this are now removed. See https://github.com/akkadotnet/Akka.TestKit.NUnit/issues/44 for details.