### PR TITLE
Update Akka.TestKit.NUnit to NUnit v4

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",

--- a/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
     <PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)" />

--- a/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
-    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitV3AdapterVersion)" />
+    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
+    <PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
-    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
+    <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitV3AdapterVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
+    <PackageReference Include="Akka.TestKit" Version="1.5.18" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
     <PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)" />
   </ItemGroup>

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
-    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="1.5.18" />
+    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
     <PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)" />
   </ItemGroup>

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
-    <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
+    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit/NUnitAssertions.cs
+++ b/src/Akka.TestKit.NUnit/NUnitAssertions.cs
@@ -19,17 +19,17 @@ namespace Akka.TestKit.NUnit
         
         public void Fail(string format = "", params object[] args)
         {
-            ClassicAssert.Fail(string.Format(format, args));
+            Assert.Fail(string.Format(format, args));
         }
 
         public void AssertTrue(bool condition, string format = "", params object[] args)
         {
-            ClassicAssert.IsTrue(condition, format, args);
+            Assert.That(condition, Is.True, string.Format(format, args));
         }
 
         public void AssertFalse(bool condition, string format = "", params object[] args)
         {
-            ClassicAssert.IsFalse(condition, format, args);
+            Assert.That(condition, Is.False, string.Format(format, args));
         }
 
         public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)

--- a/src/Akka.TestKit.NUnit/NUnitAssertions.cs
+++ b/src/Akka.TestKit.NUnit/NUnitAssertions.cs
@@ -34,7 +34,7 @@ namespace Akka.TestKit.NUnit
 
         public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)
         {
-            ClassicAssert.AreEqual(expected, actual, format, args);
+            Assert.That(actual, Is.EqualTo(expected), string.Format(format, args));
         }
 
         public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)

--- a/src/Akka.TestKit.NUnit/NUnitAssertions.cs
+++ b/src/Akka.TestKit.NUnit/NUnitAssertions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Akka.TestKit.NUnit
 {
@@ -18,22 +19,22 @@ namespace Akka.TestKit.NUnit
         
         public void Fail(string format = "", params object[] args)
         {
-            Assert.Fail(format, args);
+            ClassicAssert.Fail(format, args);
         }
 
         public void AssertTrue(bool condition, string format = "", params object[] args)
         {
-            Assert.IsTrue(condition, format, args);
+            ClassicAssert.IsTrue(condition, format, args);
         }
 
         public void AssertFalse(bool condition, string format = "", params object[] args)
         {
-            Assert.IsFalse(condition, format, args);
+            ClassicAssert.IsFalse(condition, format, args);
         }
 
         public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)
         {
-            Assert.AreEqual(expected, actual, format, args);
+            ClassicAssert.AreEqual(expected, actual, format, args);
         }
 
         public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)

--- a/src/Akka.TestKit.NUnit/NUnitAssertions.cs
+++ b/src/Akka.TestKit.NUnit/NUnitAssertions.cs
@@ -19,7 +19,7 @@ namespace Akka.TestKit.NUnit
         
         public void Fail(string format = "", params object[] args)
         {
-            ClassicAssert.Fail(format, args);
+            ClassicAssert.Fail(string.Format(format, args));
         }
 
         public void AssertTrue(bool condition, string format = "", params object[] args)

--- a/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
+++ b/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitV3AdapterVersion)" />
   </ItemGroup>

--- a/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
+++ b/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
-    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
+    <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitV3AdapterVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
+++ b/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="1.5.18" />
+    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
     <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
   </ItemGroup>
 

--- a/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
+++ b/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
+    <PackageReference Include="Akka.TestKit" Version="1.5.18" />
     <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
   </ItemGroup>
 

--- a/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
+++ b/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
-    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
+++ b/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,10 @@
 		<NUnitV3AdapterVersion>4.5.0</NUnitV3AdapterVersion>
 	</PropertyGroup>
 	<PropertyGroup>
+		<NUnitVersion>4.1.0</NUnitVersion>
+		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
+	</PropertyGroup>
+	<PropertyGroup>
 		<AkkaTestKitVersion>1.5.7</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,7 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 	<PropertyGroup>
-		<NUnitV3Version>3.13.3</NUnitV3Version>
+		<NUnitV3Version>3.14.0</NUnitV3Version>
 		<NUnitV3AdapterVersion>4.5.0</NUnitV3AdapterVersion>
 		<AkkaTestKitVersion>1.5.7</AkkaTestKitVersion>
 	</PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,13 +1,11 @@
-<Project>
+﻿<Project>
 	<PropertyGroup>
 		<Copyright>Copyright © 2013-2022</Copyright>
 		<Authors>Akka.NET Contrib</Authors>
 		<Description>TestKit for writing tests for Akka.NET using NUnit.</Description>
 		<VersionPrefix>1.5.0</VersionPrefix>
-		<PackageReleaseNotes> • Support for Akka 1.4.39
- • Support for NUnit 3.13.3
- • Now targets netstandard2.0
- • All TestKit classes now implement [FixtureLifeCycle(LifeCycle.InstancePerTestCase)] which guarantees a unique ActorSystem instance per-run. All previous TestKit hacks needed to support this are now removed. See https://github.com/akkadotnet/Akka.TestKit.NUnit/issues/44 for details.</PackageReleaseNotes>
+		<PackageReleaseNotes>• [Bump Akka.NET to 1.5.0](https://github.com/akkadotnet/akka.net/releases/tag/1.5.0)
+• [Bump NUnit3TestAdapter to 4.3.1](https://github.com/akkadotnet/Akka.TestKit.NUnit/commit/591892dd6383c94bcf7c2ef7974cf1ce02165092)</PackageReleaseNotes>
 		<PackageTags>akka;actors;actor model;Akka;concurrency;testkit;nunit</PackageTags>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
@@ -25,6 +23,6 @@
 		<NUnitAnalyzersVersion>4.1.0</NUnitAnalyzersVersion>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AkkaTestKitVersion>1.5.7</AkkaTestKitVersion>
+		<AkkaTestKitVersion>1.5.18</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,6 +22,7 @@
 	<PropertyGroup>
 		<NUnitVersion>4.1.0</NUnitVersion>
 		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
+		<NUnitAnalyzersVersion>4.1.0</NUnitAnalyzersVersion>
 	</PropertyGroup>
 	<PropertyGroup>
 		<AkkaTestKitVersion>1.5.7</AkkaTestKitVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,8 @@
 	<PropertyGroup>
 		<NUnitV3Version>3.14.0</NUnitV3Version>
 		<NUnitV3AdapterVersion>4.5.0</NUnitV3AdapterVersion>
+	</PropertyGroup>
+	<PropertyGroup>
 		<AkkaTestKitVersion>1.5.7</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,8 +16,8 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 	<PropertyGroup>
-		<NUnitVersion>3.13.3</NUnitVersion>
-		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
+		<NUnitV3Version>3.13.3</NUnitV3Version>
+		<NUnitV3AdapterVersion>4.5.0</NUnitV3AdapterVersion>
 		<AkkaTestKitVersion>1.5.7</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #111

## Changes

* ⚠️NOTE: This changes the target for `Akka.TestKit.NUnit` from `netstandard2.0` to `net6.0`. This is because the NUnit Framework itself only targets `net6.0` now. This may or may not be a change that you're comfortable with; if it's not, I understand and feel free to close this.
* Adds additional build properties to distinguish between current NUnit version and V3 NUnit version
* Uses latest NUnit packages in TestKit.NUnit
* Fixes breaking changes related to NUnit v4 assertions.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* ~This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).~ N/A (I think?)
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* ~Design discussion issue #~ N/A (I think?)
* ~Changes in public API reviewed, if any.~ N/A (I think?)
* ~I have added website documentation for this feature.~ N/A (I think?)

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
