### PR TITLE
Update RELEASE_NOTES.md for 1.5.24 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
-## [1.5.0] / March 3 2023
-- [Bump Akka.NET to 1.5.0](https://github.com/akkadotnet/akka.net/releases/tag/1.5.0)
-- [Bump NUnit3TestAdapter to 4.3.1](https://github.com/akkadotnet/Akka.TestKit.NUnit/commit/591892dd6383c94bcf7c2ef7974cf1ce02165092)
+## [1.5.24] / June 11 2024
+
+- [Bump Akka.TestKit to 1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
+- [Bump NUnit3TestAdapter to 4.5.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/97)
+- [Bump NUnit to 3.14.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/116)
 
 ## [1.4.39] / July 22 2022
  - Support for Akka 1.4.39

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,7 @@
 ## [1.5.24] / June 11 2024
-
-- [Bump Akka.TestKit to 1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
-- [Bump NUnit3TestAdapter to 4.5.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/97)
-- [Bump NUnit to 3.14.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/116)
+ - [Bump Akka.TestKit to 1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
+ - [Bump NUnit3TestAdapter to 4.5.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/97)
+ - [Bump NUnit to 3.14.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/116)
 
 ## [1.4.39] / July 22 2022
  - Support for Akka 1.4.39


### PR DESCRIPTION
## [1.5.24] / June 11 2024

- [Bump Akka.TestKit to 1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
- [Bump NUnit3TestAdapter to 4.5.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/97)
- [Bump NUnit to 3.14.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/116)