### PR TITLE
Update Akka.TestKit.NUnit to NUnit v4 (renewed)

### DIFF
--- a/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -2,7 +2,8 @@
 	
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit.Tests</AssemblyTitle>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
  
   <ItemGroup>
@@ -13,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
+    <PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit/NUnitAssertions.cs
+++ b/src/Akka.TestKit.NUnit/NUnitAssertions.cs
@@ -18,22 +18,22 @@ namespace Akka.TestKit.NUnit
         
         public void Fail(string format = "", params object[] args)
         {
-            Assert.Fail(format, args);
+            Assert.Fail(string.Format(format, args));
         }
 
         public void AssertTrue(bool condition, string format = "", params object[] args)
         {
-            Assert.IsTrue(condition, format, args);
+            Assert.That(condition, Is.True, string.Format(format, args));
         }
 
         public void AssertFalse(bool condition, string format = "", params object[] args)
         {
-            Assert.IsFalse(condition, format, args);
+            Assert.That(condition, Is.False, string.Format(format, args));
         }
 
         public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)
         {
-            Assert.AreEqual(expected, actual, format, args);
+            Assert.That(actual, Is.EqualTo(expected), string.Format(format, args));
         }
 
         public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)

--- a/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
+++ b/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
@@ -2,7 +2,8 @@
 	
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit3.Tests</AssemblyTitle>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
  
   <ItemGroup>
@@ -11,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
-    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
+    <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitV3AdapterVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
+++ b/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.NUnit</AssemblyTitle>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
-    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageReference Include="NUnit" Version="$(NUnitV3Version)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,8 +16,15 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 	<PropertyGroup>
-		<NUnitVersion>3.14.0</NUnitVersion>
+		<NUnitV3Version>3.14.0</NUnitV3Version>
+		<NUnitV3AdapterVersion>4.5.0</NUnitV3AdapterVersion>
+	</PropertyGroup>
+	<PropertyGroup>
+		<NUnitVersion>4.1.0</NUnitVersion>
 		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
+		<NUnitAnalyzersVersion>4.1.0</NUnitAnalyzersVersion>
+	</PropertyGroup>
+	<PropertyGroup>
 		<AkkaTestKitVersion>1.5.26</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #111 

## Changes

This builds upon the work of @SeanKilleen in #112. On top of #112 it adds .NET Framework 4.6.2 as an additional target framework (as NUnit 4 dropped netstandard 2.0 support in favour of supporting both .NET standard 6 and .NET Framework 4.6.2, cf. [breaking changes of NUnit 4](https://docs.nunit.org/articles/nunit/release-notes/breaking-changes.html)).

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* ~Design discussion issue #~ (not needed I guess?)
* [x] Changes in public API reviewed, if any.
* ~I have added website documentation for this feature.~ (not needed I guess?)

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
