### PR TITLE
Bump Akka.TestKit dependency to 1.5.30 + Akka.TestKit.NUnit package to 1.5.30

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
-## [1.6.0] / September 2024
+## [1.5.30] / October 2024
+- Bump `Akka.TestKit` to [1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
+
+## [1.5.28] / September 2024
 - Bump `Akka.TestKit` to [1.5.28](https://github.com/akkadotnet/akka.net/releases/tag/1.5.28)
 - Bump `NUnit3TestAdapter` to [4.6.0](https://github.com/nunit/nunit3-vs-adapter/releases/tag/V4.6.0)
 - Add `NUnit.Analyzers` version [4.3.0](https://github.com/nunit/nunit.analyzers/releases/tag/4.3.0) to ensure we follow NUnit best practices.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,11 +1,10 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year)</Copyright>
     <Authors>Akka.NET Contrib</Authors>
     <Description>TestKit for writing tests for Akka.NET using NUnit.</Description>
-    <VersionPrefix>1.6.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../../RELEASE_NOTES.md").Substring(0,567))</PackageReleaseNotes>
+    <VersionPrefix>1.5.30</VersionPrefix>
     <PackageTags>akka;actors;actor model;Akka;concurrency;testkit;nunit</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageIcon>akka.png</PackageIcon><!-- https://github.com/NuGet/Home/wiki/Packaging-Icon-within-the-nupkg -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,8 @@
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year)</Copyright>
     <Authors>Akka.NET Contrib</Authors>
     <Description>TestKit for writing tests for Akka.NET using NUnit.</Description>
-    <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../../RELEASE_NOTES.md").Substring(0,567))</PackageReleaseNotes>
     <VersionPrefix>1.5.30</VersionPrefix>
+    <PackageReleaseNotes>• Bump Akka.TestKit to [1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)</PackageReleaseNotes>
     <PackageTags>akka;actors;actor model;Akka;concurrency;testkit;nunit</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageIcon>akka.png</PackageIcon><!-- https://github.com/NuGet/Home/wiki/Packaging-Icon-within-the-nupkg -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl><!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaTestKitVersion>1.5.28</AkkaTestKitVersion>
+    <AkkaTestKitVersion>1.5.30</AkkaTestKitVersion>
     <MicrosoftNetTestSdkVersion>17.11.1</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.2.2</NUnit4Version>


### PR DESCRIPTION
## Changes

This pull request bumps `Akka.TestKit` dependency to version 1.5.30 and removes the preview version I introduced in #136 (where `Akka.TestKit.NUnit` was published as `1.6.0-preview.1`). Instead, both `Akka.TestKit.NUnit` and `Akka.TestKit.NUnit3` NuGet packages use the same version as `Akka.TestKit`, 1.5.30.

## Checklist

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).