### PR TITLE
Safer formatting of assertion messages

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -30,7 +30,7 @@ jobs:
   windows-latest:
     name: windows-latest
     runs-on: windows-latest
-    
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4.1.1
@@ -57,11 +57,11 @@ jobs:
 
       - name: "dotnet pack"
         run: dotnet pack -c Release -o ./bin/nuget
-          
+
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4.1.1
@@ -81,11 +81,11 @@ jobs:
 
       - name: "dotnet build"
         run: dotnet build -c Release
-      
+
       # .NET Framework tests can't run reliably on Linux, so we only do .NET Core
       - name: "dotnet test"
         shell: bash
-        run: dotnet test -c Release -f net6.0
+        run: dotnet test -c Release -f net8.0
 
       - name: "dotnet pack"
         run: dotnet pack -c Release -o ./bin/nuget

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
     <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaTestKitVersion>1.5.32</AkkaTestKitVersion>
+    <AkkaTestKitVersion>1.5.33</AkkaTestKitVersion>
     <MicrosoftNetTestSdkVersion>17.12.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.2.2</NUnit4Version>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,22 +6,16 @@
     <Description>TestKit for writing tests for Akka.NET using NUnit.</Description>
     <PackageTags>akka;actors;actor model;Akka;concurrency;testkit;nunit</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIcon>akka.png</PackageIcon>
-    <!-- https://github.com/NuGet/Home/wiki/Packaging-Icon-within-the-nupkg -->
+    <PackageIcon>akka.png</PackageIcon><!-- https://github.com/NuGet/Home/wiki/Packaging-Icon-within-the-nupkg -->
     <PackageProjectUrl>https://github.com/AkkaNetContrib/Akka.TestKit.Nunit</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <!-- https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/ -->
+    <PackageReadmeFile>README.md</PackageReadmeFile><!-- https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/ -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <LangVersion>10.0</LangVersion>
-    <ContinuousIntegrationBuild Condition=" '$(Configuration)' == 'Release' ">true</ContinuousIntegrationBuild>
-    <!-- https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild -->
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <!-- https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#symbol-packages -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#embeduntrackedsources -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
+    <LangVersion>13.0</LangVersion>
+    <ContinuousIntegrationBuild Condition=" '$(Configuration)' == 'Release' ">true</ContinuousIntegrationBuild><!-- https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder><!-- https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#symbol-packages -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources><!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#embeduntrackedsources -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl><!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
   </PropertyGroup>
   <PropertyGroup>
     <AkkaTestKitVersion>1.5.33</AkkaTestKitVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <MicrosoftNetTestSdkVersion>17.12.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.2.2</NUnit4Version>
-    <NUnitAnalyzersVersion>4.4.0</NUnitAnalyzersVersion>
+    <NUnitAnalyzersVersion>4.5.0</NUnitAnalyzersVersion>
     <NUnitTestAdapterVersion>4.6.0</NUnitTestAdapterVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
     <AkkaTestKitVersion>1.5.33</AkkaTestKitVersion>
     <MicrosoftNetTestSdkVersion>17.12.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
-    <NUnit4Version>4.2.2</NUnit4Version>
+    <NUnit4Version>4.3.2</NUnit4Version>
     <NUnitAnalyzersVersion>4.5.0</NUnitAnalyzersVersion>
     <NUnitTestAdapterVersion>4.6.0</NUnitTestAdapterVersion>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.33 January 4th 2025 ####
+- Safer formatting of assertion messages
+- Bump `NUnit` to [4.3.2](https://github.com/nunit/nunit/releases/tag/4.3.2)
+- Bump `NUnit.Analyzers` to [4.5.0](https://github.com/nunit/nunit.analyzers/releases/tag/4.5.0)
+- Bump `Akka.TestKit` to [1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)
+
 #### 1.5.32 December 20th 2024 ####
 - Bump `Akka.TestKit` to [1.5.32](https://github.com/akkadotnet/akka.net/releases/tag/1.5.32)
 - Bump `NUnit3TestAdapter` to [4.6.0](https://github.com/nunit/nunit3-vs-adapter/releases/tag/V4.6.0)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "6.0.428"
+    "version": "9.0.101"
   }
 }

--- a/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
+++ b/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
@@ -12,12 +12,7 @@ namespace Akka.TestKit.NUnit.Tests
     [Parallelizable(ParallelScope.All)]
     public class AssertionsTests : TestKit
     {
-        private readonly NUnitAssertions _assertions;
-
-        public AssertionsTests()
-        {
-            _assertions = new NUnitAssertions();
-        }
+        private readonly NUnitAssertions _assertions = new();
 
         [Test]
         public void Fail_should_throw()
@@ -71,6 +66,31 @@ namespace Akka.TestKit.NUnit.Tests
         public void AssertEqualWithComparer_should_succeed_on_equal()
         {
             _assertions.AssertEqual(42, 4711, (x, y) => true);
+        }
+
+        [Test]
+        public void Assert_should_not_format_message_when_no_arguments_are_specified()
+        {
+            const string testMessage = "{Value} with different format placeholders {0}";
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    code: () => _assertions.Fail(testMessage),
+                    constraint: Throws.Exception.TypeOf<AssertionException>().And.Message.Contains(testMessage));
+                Assert.That(
+                    code: () => _assertions.AssertTrue(false, testMessage),
+                    constraint: Throws.Exception.TypeOf<AssertionException>().And.Message.Contains(testMessage));
+                Assert.That(
+                    code: () => _assertions.AssertFalse(true, testMessage),
+                    constraint: Throws.Exception.TypeOf<AssertionException>().And.Message.Contains(testMessage));
+                Assert.That(
+                    code: () => _assertions.AssertEqual(4, 2, testMessage),
+                    constraint: Throws.Exception.TypeOf<AssertionException>().And.Message.Contains(testMessage));
+                Assert.That(
+                    code: () => _assertions.AssertEqual(4, 2, (_, _) => false, testMessage),
+                    constraint: Throws.Exception.TypeOf<AssertionException>().And.Message.Contains(testMessage));
+            });
         }
     }
 }

--- a/src/Akka.TestKit.NUnit/NUnitAssertions.cs
+++ b/src/Akka.TestKit.NUnit/NUnitAssertions.cs
@@ -15,30 +15,40 @@ namespace Akka.TestKit.NUnit
     /// </summary>
     public class NUnitAssertions  : ITestKitAssertions
     {
-        
         public void Fail(string format = "", params object[] args)
         {
-            Assert.Fail(string.Format(format, args));
+            Assert.Fail(NUnitAssertBase.ConvertMessageWithArgs(format, args));
         }
 
         public void AssertTrue(bool condition, string format = "", params object[] args)
         {
-            Assert.That(condition, Is.True, string.Format(format, args));
+            Assert.That(condition, Is.True, NUnitAssertBase.ConvertMessageWithArgs(format, args));
         }
 
         public void AssertFalse(bool condition, string format = "", params object[] args)
         {
-            Assert.That(condition, Is.False, string.Format(format, args));
+            Assert.That(condition, Is.False, NUnitAssertBase.ConvertMessageWithArgs(format, args));
         }
 
         public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)
         {
-            Assert.That(actual, Is.EqualTo(expected), string.Format(format, args));
+            Assert.That(actual, Is.EqualTo(expected), NUnitAssertBase.ConvertMessageWithArgs(format, args));
         }
 
         public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)
         {
-            Assert.That(actual, Is.EqualTo(expected).Using<T>(comparer), string.Format(format, args));
+            Assert.That(actual, Is.EqualTo(expected).Using<T>(comparer), NUnitAssertBase.ConvertMessageWithArgs(format, args));
+        }
+
+        /// <remarks>
+        /// This class only exists to allow us to call <c>NUnit.Framework.AssertBase.ConvertMessageWithArgs</c>.
+        /// As of NUnit 4.3.1, this method is declared <c>protected</c> and thus cannot be called directly.
+        /// See https://github.com/nunit/nunit/blob/4.3.1/src/NUnitFramework/framework/AssertBase.cs#L10-L14.
+        /// </remarks>
+        private sealed class NUnitAssertBase : AssertBase
+        {
+            public new static string ConvertMessageWithArgs(string message, object[] args) =>
+                AssertBase.ConvertMessageWithArgs(message, args);
         }
     }
 }


### PR DESCRIPTION
Fixes #156.

## Changes

While switching to NUnit v4 in #136, we used a naive approach to formatting the assertion message, where both the message and arguments specified by the caller are forwarded to `string.Format`. This caused assertions to fail when messages contained special characters recognized by `string.Format`, even when the caller did not intend any formatting to take place (only message string was specified, no arguments) - see discussion in #156, thanks @busraozis for reporting.

The surprising aspect of this issue, as [reported](https://github.com/akkadotnet/Akka.TestKit.NUnit/issues/156#issuecomment-2561949900) by @UrsMetz, was that using the same message with NUnit's "classic assert" succeeded, despite presence of special characters in the assertion message. Looking at NUnit's implementation I realized this is because NUnit does not pass the message and arguments directly to `string.Format`. Instead, they define a method [`NUnit.Framework.AssertBase.ConvertMessageWithArgs`](https://github.com/nunit/nunit/blob/4.3.2/src/NUnitFramework/framework/AssertBase.cs#L10-L14):

<img width="619" alt="image" src="https://github.com/user-attachments/assets/f4070c9f-15fd-46a3-82b8-3c43c6a6874b" />

This method does _not_ call `string.Format` when no arguments are specified by the caller, i.e. it uses the assertion message as-is. This allows the caller to use any characters in the assertion message, as long as they don't specify any format arguments (which is most commonly the case, including the @busraozis issue).

This pull request updates `Akka.TestKit.NUnit` to use NUnit's `ConvertMessageWithArgs` method for formatting the assertion message, and adds a test that verifies that all `ITestKitAssertions` methods can be called with assertion message that contains special `string.Format` sequences (like `"{0}"`), as long as no format arguments are specified.

### Other changes
- I included pending dependabot commits bumping:
    - NUnit from 4.2.2 to 4.3.2
    - NUnit.Analyzers from 4.4.0 to 4.5.0
    - Akka.TestKit from 1.5.32 to 1.5.33
- I changed .NET SDK used to build this project from .NET SDK 6 (which is no longer supported by Microsoft) to the latest .NET SDK 9 and updated C# to the latest version 13 (we still target .NET Framework 4.6.2 and  .NET 6, just with the help of the latest compiler and build tools).

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
