### PR TITLE
Bump Akka.TestKit from 1.5.33 to 1.5.34

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl><!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaTestKitVersion>1.5.33</AkkaTestKitVersion>
+    <AkkaTestKitVersion>1.5.34</AkkaTestKitVersion>
     <MicrosoftNetTestSdkVersion>17.12.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.3.2</NUnit4Version>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 1.5.34 January 7th 2025 ####
+- Bump `Akka.TestKit` to [1.5.34](https://github.com/akkadotnet/akka.net/releases/tag/1.5.34)
+
 #### 1.5.33 January 4th 2025 ####
 - Safer formatting of assertion messages
 - Bump `NUnit` to [4.3.2](https://github.com/nunit/nunit/releases/tag/4.3.2)


### PR DESCRIPTION
## Changes

Bumps Akka.TestKit from 1.5.33 to [1.5.34](https://github.com/akkadotnet/akka.net/releases/tag/1.5.34).

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).