### PR TITLE
Bump Akka.TestKit from 1.5.34 to 1.5.35

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl><!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaTestKitVersion>1.5.34</AkkaTestKitVersion>
+    <AkkaTestKitVersion>1.5.35</AkkaTestKitVersion>
     <MicrosoftNetTestSdkVersion>17.12.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.3.2</NUnit4Version>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     <MicrosoftNetTestSdkVersion>17.12.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.3.2</NUnit4Version>
-    <NUnitAnalyzersVersion>4.5.0</NUnitAnalyzersVersion>
+    <NUnitAnalyzersVersion>4.6.0</NUnitAnalyzersVersion>
     <NUnitTestAdapterVersion>4.6.0</NUnitTestAdapterVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.35 January 13th 2025 ####
+- Bump `Akka.TestKit` to [1.5.35](https://github.com/akkadotnet/akka.net/releases/tag/1.5.35)
+- Bump `NUnit.Analyzers` to [4.6.0](https://github.com/nunit/nunit.analyzers/releases/tag/4.6.0)
+
 #### 1.5.34 January 7th 2025 ####
 - Bump `Akka.TestKit` to [1.5.34](https://github.com/akkadotnet/akka.net/releases/tag/1.5.34)
 


### PR DESCRIPTION
## Changes

Bumps Akka.TestKit from 1.5.34 to [1.5.35](https://github.com/akkadotnet/akka.net/releases/tag/1.5.35).

Also bumps NUnit.Analyzers from 4.5.0 to [4.6.0](https://github.com/nunit/nunit.analyzers/releases/tag/4.6.0).

## Checklist

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
