### PR TITLE
Bump AkkaTestKitVersion to 1.6.0

### DIFF
--- a/Akka.TestKit.Nunit.sln
+++ b/Akka.TestKit.Nunit.sln
@@ -11,6 +11,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md
+		appsettings.json = appsettings.json
+		build.ps1 = build.ps1
+		Directory.Build.props = Directory.Build.props
+		Directory.Generated.props = Directory.Generated.props
+		global.json = global.json
 	EndProjectSection
 EndProject
 Global

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
     <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaTestKitVersion>1.5.32</AkkaTestKitVersion>
+    <AkkaTestKitVersion>1.6.0</AkkaTestKitVersion>
     <MicrosoftNetTestSdkVersion>17.12.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.2.2</NUnit4Version>

--- a/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
+++ b/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
@@ -5,72 +5,194 @@
 // </copyright>
 //----------------------------------------------------------------------
 
+using System;
+using System.Threading.Tasks;
+using Akka.Configuration;
 using NUnit.Framework;
 
-namespace Akka.TestKit.NUnit.Tests
+namespace Akka.TestKit.NUnit.Tests;
+
+[Parallelizable(ParallelScope.All)]
+public class AssertionsTests : TestKit
 {
-    [Parallelizable(ParallelScope.All)]
-    public class AssertionsTests : TestKit
+    private readonly NUnitAssertions _assertions;
+
+    public AssertionsTests()
     {
-        private readonly NUnitAssertions _assertions;
+        _assertions = new NUnitAssertions();
+    }
 
-        public AssertionsTests()
-        {
-            _assertions = new NUnitAssertions();
-        }
+    [Test]
+    public void Fail_should_throw()
+    {
+        Assert.Throws<AssertionException>(() => _assertions.Fail());
+    }
 
-        [Test]
-        public void Fail_should_throw()
-        {
-            Assert.Throws<AssertionException>(() => _assertions.Fail());
-        }
+    [Test]
+    public void AssertTrue_should_throw_on_false()
+    {
+        Assert.Throws<AssertionException>(() => _assertions.AssertTrue(false));
+    }
 
-        [Test]
-        public void AssertTrue_should_throw_on_false()
-        {
-            Assert.Throws<AssertionException>(() => _assertions.AssertTrue(false));
-        }
+    [Test]
+    public void AssertTrue_should_succeed_on_true()
+    {
+        _assertions.AssertTrue(true);
+    }
 
-        [Test]
-        public void AssertTrue_should_succeed_on_true()
-        {
-            _assertions.AssertTrue(true);
-        }
+    [Test]
+    public void AssertFalse_should_throw_on_true()
+    {
+        Assert.Throws<AssertionException>(() => _assertions.AssertFalse(true));
+    }
 
-        [Test]
-        public void AssertFalse_should_throw_on_true()
-        {
-            Assert.Throws<AssertionException>(() => _assertions.AssertFalse(true));
-        }
+    [Test]
+    public void AssertFalse_should_succeed_on_false()
+    {
+        _assertions.AssertFalse(false);
+    }
 
-        [Test]
-        public void AssertFalse_should_succeed_on_false()
-        {
-            _assertions.AssertFalse(false);
-        }
+    [Test]
+    public void AssertEqual_should_throw_on_not_equal()
+    {
+        Assert.Throws<AssertionException>(() => _assertions.AssertEqual(42, 4711));
+    }
 
-        [Test]
-        public void AssertEqual_should_throw_on_not_equal()
-        {
-            Assert.Throws<AssertionException>(() => _assertions.AssertEqual(42, 4711));
-        }
+    [Test]
+    public void AssertEqual_should_succeed_on_equal()
+    {
+        _assertions.AssertEqual(42, 42);
+    }
 
-        [Test]
-        public void AssertEqual_should_succeed_on_equal()
-        {
-            _assertions.AssertEqual(42, 42);
-        }
+    [Test]
+    public void AssertEqualWithComparer_should_throw_on_not_equal()
+    {
+        Assert.Throws<AssertionException>(() => _assertions.AssertEqual(42, 1142, Comparer));
+    }
 
-        [Test]
-        public void AssertEqualWithComparer_should_throw_on_not_equal()
-        {
-            Assert.Throws<AssertionException>(() => _assertions.AssertEqual(42, 42, (x, y) => false));
-        }
+    [Test]
+    public void AssertEqualWithComparer_should_succeed_on_equal()
+    {
+        Assert.DoesNotThrow(() => _assertions.AssertEqual(42, 42, Comparer));
+    }
 
-        [Test]
-        public void AssertEqualWithComparer_should_succeed_on_equal()
+    private static bool Comparer(int x, int y) => x == y;
+    
+    [TestCaseSource(nameof(_exceptionData))]
+    public void AssertThrows_should_succeed_on_any_thrown_exception(Exception exception)
+    {
+        Assert.That(_assertions.AssertThrows(ThisThrows), Is.EqualTo(exception));
+        return;
+
+        void ThisThrows()
         {
-            _assertions.AssertEqual(42, 4711, (x, y) => true);
+            throw exception;
         }
     }
+
+    [TestCaseSource(nameof(_exceptionData))]
+    public async Task AssertThrows_should_succeed_on_any_thrown_exception_async(Exception exception)
+    {
+        await Assert.ThatAsync(() => _assertions.AssertThrowsAsync(ThisThrows), Is.EqualTo(exception));
+        return;
+
+        async Task ThisThrows()
+        {
+            await Task.Yield();
+            throw exception;
+        }
+    }
+
+    [Test]
+    public void AssertThrows_should_fail_when_no_exception_was_thrown()
+    {
+        Assert.That(() => _assertions.AssertThrows(ThisDoesNotThrows), Throws.TypeOf(typeof(AssertionException)));
+        return;
+
+        void ThisDoesNotThrows()
+        {
+        }
+    }
+
+    [Test]
+    public async Task AssertThrows_should_fail_when_no_exception_was_thrown_async()
+    {
+        await Assert.ThatAsync(() => _assertions.AssertThrowsAsync(ThisDoesNotThrows), Throws.TypeOf(typeof(AssertionException)));
+        return;
+
+        async Task ThisDoesNotThrows()
+        {
+            await Task.Yield();
+        }
+    }
+
+    [TestCaseSource(nameof(_exceptionData))]
+    public void Generic_AssertThrows_should_succeed_only_on_specific_exception(Exception exception)
+    {
+        if (exception is ConfigurationException ex)
+        {
+            Assert.That(_assertions.AssertThrows<ConfigurationException>(ThisThrows), Is.EqualTo(ex));
+        }
+        else
+        {
+            Assert.Throws<AssertionException>(() => _assertions.AssertThrows<ConfigurationException>(ThisThrows));
+        }
+        return;
+
+        void ThisThrows()
+        {
+            throw exception;
+        }
+    }
+
+    [TestCaseSource(nameof(_exceptionData))]
+    public async Task Generic_AssertThrows_should_succeed_only_on_specific_exception_async(Exception exception)
+    {
+        if (exception is ConfigurationException ex)
+        {
+            await Assert.ThatAsync(() => _assertions.AssertThrowsAsync<ConfigurationException>(ThisThrows), Is.EqualTo(ex));
+        }
+        else
+        {
+            Assert.ThrowsAsync<AssertionException>(async () => await _assertions.AssertThrowsAsync<ConfigurationException>(ThisThrows));
+        }
+        return;
+
+        async Task ThisThrows()
+        {
+            await Task.Yield();
+            throw exception;
+        }
+    }
+
+    [Test]
+    public void Generic_AssertThrows_should_fail_when_no_exception_was_thrown()
+    {
+        Assert.That(() => _assertions.AssertThrows<ConfigurationException>(ThisDoesNotThrows), Throws.TypeOf(typeof(AssertionException)));
+        return;
+
+        void ThisDoesNotThrows()
+        {
+        }
+    }
+
+    [Test]
+    public async Task Generic_AssertThrows_should_fail_when_no_exception_was_thrown_async()
+    {
+        await Assert.ThatAsync(() => _assertions.AssertThrowsAsync<ConfigurationException>(ThisDoesNotThrows), Throws.TypeOf(typeof(AssertionException)));
+        return;
+
+        async Task ThisDoesNotThrows()
+        {
+            await Task.Yield();
+        }
+    }
+
+    private static object[] _exceptionData =
+    {
+        new object[] {new Exception("Wheee")},
+        new object[] {new ConfigurationException("Wheee")},
+        new object[] {new TimeoutException("Wheee")},
+        new object[] {new OperationCanceledException("Wheee")},
+    };
 }

--- a/src/Akka.TestKit.NUnit/NUnitAssertions.cs
+++ b/src/Akka.TestKit.NUnit/NUnitAssertions.cs
@@ -6,39 +6,81 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Akka.TestKit.NUnit
+namespace Akka.TestKit.NUnit;
+
+/// <summary>
+/// Assertions for NUnit
+/// </summary>
+public class NUnitAssertions  : ITestKitAssertions
 {
-    /// <summary>
-    /// Assertions for NUnit
-    /// </summary>
-    public class NUnitAssertions  : ITestKitAssertions
-    {
         
-        public void Fail(string format = "", params object[] args)
-        {
-            Assert.Fail(string.Format(format, args));
-        }
+    public void Fail(string format = "", params object[] args)
+    {
+        Assert.Fail(string.Format(format, args));
+    }
 
-        public void AssertTrue(bool condition, string format = "", params object[] args)
-        {
-            Assert.That(condition, Is.True, string.Format(format, args));
-        }
+    public void AssertTrue(bool condition, string format = "", params object[] args)
+    {
+        Assert.That(condition, Is.True, string.Format(format, args));
+    }
 
-        public void AssertFalse(bool condition, string format = "", params object[] args)
-        {
-            Assert.That(condition, Is.False, string.Format(format, args));
-        }
+    public void AssertFalse(bool condition, string format = "", params object[] args)
+    {
+        Assert.That(condition, Is.False, string.Format(format, args));
+    }
 
-        public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)
-        {
-            Assert.That(actual, Is.EqualTo(expected), string.Format(format, args));
-        }
+    public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)
+    {
+        Assert.That(actual, Is.EqualTo(expected), string.Format(format, args));
+    }
 
-        public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)
+    public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)
+    {
+        Assert.That(actual, Is.EqualTo(expected).Using<T>(comparer), string.Format(format, args));
+    }
+
+    public Exception AssertThrows(Action action)
+    {
+        return Assert.Catch(() => action());
+    }
+
+    public TException AssertThrows<TException>(Action action) where TException : Exception
+    {
+        return Assert.Throws<TException>(() => action());
+    }
+
+    // No Nunit built-in solution for these, we have to do this manually
+    public async Task<Exception> AssertThrowsAsync(Func<Task> action)
+    {
+        try
         {
-            Assert.That(actual, Is.EqualTo(expected).Using<T>(comparer), string.Format(format, args));
+            await action();
         }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+        throw new AssertionException("Expected an exception to be thrown but none was thrown.");
+    }
+
+    // No Nunit built-in solution for these, we have to do this manually
+    public async Task<TException> AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception
+    {
+        try
+        {
+            await action();
+        }
+        catch (TException ex)
+        {
+            return ex;
+        }
+        catch (Exception ex)
+        {
+            throw new AssertionException($"Expected {typeof(TException).Name} to be thrown, but {ex.GetType()} was thrown instead.", ex);
+        }
+        throw new AssertionException($"Expected {typeof(TException).Name} to be thrown but none was thrown instead.");
     }
 }

--- a/src/Akka.TestKit.NUnit/TestKit.cs
+++ b/src/Akka.TestKit.NUnit/TestKit.cs
@@ -10,113 +10,112 @@ using Akka.Actor;
 using Akka.Configuration;
 using NUnit.Framework;
 
-namespace Akka.TestKit.NUnit
+namespace Akka.TestKit.NUnit;
+
+/// <summary>
+/// TestKit for NUnit.
+/// </summary>
+/// 
+[TestFixture]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+public class TestKit : TestKitBase, IDisposable
 {
+    private static readonly NUnitAssertions _assertions = new();
+    private readonly Config _config;
+    private readonly string _actorSystemName;
+    private bool _isDisposed; //Automatically initialized to false;
+
     /// <summary>
-    /// TestKit for NUnit.
+    /// Create a new instance of the <see cref="TestKit"/> for NUnit class.
+    /// If no <paramref name="system"/> is passed in, a new system 
+    /// with <see cref="DefaultConfig"/> will be created.
     /// </summary>
-    /// 
-    [TestFixture]
-    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
-    public class TestKit : TestKitBase, IDisposable
+    /// <param name="system">Optional: The actor system.</param>
+    public TestKit(ActorSystem system = null)
+        : base(_assertions, system)
     {
-        private static readonly NUnitAssertions _assertions = new NUnitAssertions();
-        private readonly Config _config;
-        private readonly string _actorSystemName;
-        private bool _isDisposed; //Automatically initialized to false;
+    }
 
-        /// <summary>
-        /// Create a new instance of the <see cref="TestKit"/> for NUnit class.
-        /// If no <paramref name="system"/> is passed in, a new system 
-        /// with <see cref="DefaultConfig"/> will be created.
-        /// </summary>
-        /// <param name="system">Optional: The actor system.</param>
-        public TestKit(ActorSystem system = null)
-            : base(_assertions, system)
-        {
-        }
-
-        /// <summary>
-        /// Create a new instance of the <see cref="TestKit"/> for NUnit class.
-        /// A new system with the specified configuration will be created.
-        /// </summary>
-        /// <param name="config">The configuration to use for the system.</param>
-        /// <param name="actorSystemName">Optional: the name of the system. Default: "test"</param>
-        public TestKit(Config config, string actorSystemName = null)
-            : base(_assertions, config, actorSystemName)
-        {
-            _config = config;
-            _actorSystemName = actorSystemName;
-        }
+    /// <summary>
+    /// Create a new instance of the <see cref="TestKit"/> for NUnit class.
+    /// A new system with the specified configuration will be created.
+    /// </summary>
+    /// <param name="config">The configuration to use for the system.</param>
+    /// <param name="actorSystemName">Optional: the name of the system. Default: "test"</param>
+    public TestKit(Config config, string actorSystemName = null)
+        : base(_assertions, config, actorSystemName)
+    {
+        _config = config;
+        _actorSystemName = actorSystemName;
+    }
 
 
-        /// <summary>
-        /// Create a new instance of the <see cref="TestKit"/> for NUnit class.
-        /// A new system with the specified configuration will be created.
-        /// </summary>
-        /// <param name="config">The configuration to use for the system.</param>
-        public TestKit(string config)
-            : base(_assertions, ConfigurationFactory.ParseString(config))
-        {
-            _config = ConfigurationFactory.ParseString(config);
-        }
+    /// <summary>
+    /// Create a new instance of the <see cref="TestKit"/> for NUnit class.
+    /// A new system with the specified configuration will be created.
+    /// </summary>
+    /// <param name="config">The configuration to use for the system.</param>
+    public TestKit(string config)
+        : base(_assertions, ConfigurationFactory.ParseString(config))
+    {
+        _config = ConfigurationFactory.ParseString(config);
+    }
 
-        public new static Config DefaultConfig { get { return TestKitBase.DefaultConfig; } }
-        public new static Config FullDebugConfig { get { return TestKitBase.FullDebugConfig; } }
+    public new static Config DefaultConfig { get { return TestKitBase.DefaultConfig; } }
+    public new static Config FullDebugConfig { get { return TestKitBase.FullDebugConfig; } }
 
-        protected static NUnitAssertions Assertions { get { return _assertions; } }
+    protected static NUnitAssertions Assertions { get { return _assertions; } }
         
-        /// <summary>
-        /// This method is called after each test finishes, which calls
-        /// into the AfterAll method.
-        /// </summary>
-        [TearDown]
-        public void ShutDownActorSystemOnTearDown()
-        {
-            AfterAll();
-        }
+    /// <summary>
+    /// This method is called after each test finishes, which calls
+    /// into the AfterAll method.
+    /// </summary>
+    [TearDown]
+    public void ShutDownActorSystemOnTearDown()
+    {
+        AfterAll();
+    }
 
-        /// <summary>
-        /// This method is called when a test ends. 
-        /// <remarks>If you override this, make sure you either call 
-        /// base.AfterTest() or <see cref="TestKitBase.Shutdown(System.Nullable{System.TimeSpan},bool)">TestKitBase.Shutdown</see> to shut down
-        /// the system. Otherwise you'll leak memory.
-        /// </remarks>
-        /// </summary>
-        protected virtual void AfterAll()
-        {
-            Shutdown();
-        }
+    /// <summary>
+    /// This method is called when a test ends. 
+    /// <remarks>If you override this, make sure you either call 
+    /// base.AfterTest() or <see cref="TestKitBase.Shutdown(System.Nullable{System.TimeSpan},bool)">TestKitBase.Shutdown</see> to shut down
+    /// the system. Otherwise you'll leak memory.
+    /// </remarks>
+    /// </summary>
+    protected virtual void AfterAll()
+    {
+        Shutdown();
+    }
 
-        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            //Take this object off the finalization queue and prevent finalization code for this object
-            //from executing a second time.
-            GC.SuppressFinalize(this);
-        }
+    /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        //Take this object off the finalization queue and prevent finalization code for this object
+        //from executing a second time.
+        GC.SuppressFinalize(this);
+    }
 
-        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
-        /// <param name="disposing">if set to <c>true</c> the method has been called directly or indirectly by a 
-        /// user's code. Managed and unmanaged resources will be disposed.<br />
-        /// if set to <c>false</c> the method has been called by the runtime from inside the finalizer and only 
-        /// unmanaged resources can be disposed.</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            // If disposing equals false, the method has been called by the
-            // runtime from inside the finalizer and you should not reference
-            // other objects. Only unmanaged resources can be disposed.
+    /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+    /// <param name="disposing">if set to <c>true</c> the method has been called directly or indirectly by a 
+    /// user's code. Managed and unmanaged resources will be disposed.<br />
+    /// if set to <c>false</c> the method has been called by the runtime from inside the finalizer and only 
+    /// unmanaged resources can be disposed.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        // If disposing equals false, the method has been called by the
+        // runtime from inside the finalizer and you should not reference
+        // other objects. Only unmanaged resources can be disposed.
 
-            //Make sure Dispose does not get called more than once, by checking the disposed field
-            if (!_isDisposed)
+        //Make sure Dispose does not get called more than once, by checking the disposed field
+        if (!_isDisposed)
+        {
+            if (disposing)
             {
-                if (disposing)
-                {
-                    AfterAll();
-                }
+                AfterAll();
             }
-            _isDisposed = true;
         }
+        _isDisposed = true;
     }
 }


### PR DESCRIPTION
Contains all of the nescessary code to support the FluentAssertions changes introduced in the Akka 1.6 branch.

Will not work until that branch is released.