### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl><!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaTestKitVersion>1.5.37</AkkaTestKitVersion>
+    <AkkaTestKitVersion>1.5.59</AkkaTestKitVersion>
     <MicrosoftNetTestSdkVersion>17.13.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.3.2</NUnit4Version>

--- a/Directory.Generated.props
+++ b/Directory.Generated.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix/>
-    <PackageReleaseNotes/>
+    <VersionPrefix>1.5.59</VersionPrefix>
+    <PackageReleaseNotes>- Bump `Akka.TestKit` to [1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 1.5.59 January 26th 2025 ####
+- Bump `Akka.TestKit` to [1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+
 #### 1.5.35 January 13th 2025 ####
 - Bump `Akka.TestKit` to [1.5.35](https://github.com/akkadotnet/akka.net/releases/tag/1.5.35)
 - Bump `NUnit.Analyzers` to [4.6.0](https://github.com/nunit/nunit.analyzers/releases/tag/4.6.0)


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)