### PR TITLE
Update Akka.TestKit to 1.5.60

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl><!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaTestKitVersion>1.5.59</AkkaTestKitVersion>
+    <AkkaTestKitVersion>1.5.60</AkkaTestKitVersion>
     <MicrosoftNetTestSdkVersion>17.13.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.3.2</NUnit4Version>


### PR DESCRIPTION
## Summary
- Updates AkkaTestKitVersion from 1.5.59 to 1.5.60

## Test plan
- [x] Build succeeds
- [x] All tests pass (15/15 on net8.0 and net462)