### PR TITLE
Bump Akka.TestKit to 1.5.64, implement new assertion methods

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl><!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaTestKitVersion>1.5.60</AkkaTestKitVersion>
+    <AkkaTestKitVersion>1.5.64</AkkaTestKitVersion>
     <MicrosoftNetTestSdkVersion>17.13.0</MicrosoftNetTestSdkVersion>
     <NUnit3Version>3.14.0</NUnit3Version>
     <NUnit4Version>4.3.2</NUnit4Version>

--- a/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
+++ b/src/Akka.TestKit.NUnit.Tests/AssertionsTests.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //----------------------------------------------------------------------
 
+using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit.Tests
@@ -91,6 +93,69 @@ namespace Akka.TestKit.NUnit.Tests
                     code: () => _assertions.AssertEqual(4, 2, (_, _) => false, testMessage),
                     constraint: Throws.Exception.TypeOf<AssertionException>().And.Message.Contains(testMessage));
             });
+        }
+
+        [Test]
+        public void AssertThrows_should_succeed_when_exception_is_thrown()
+        {
+            _assertions.AssertThrows(() => throw new Exception("Test exception"));
+        }
+
+        [Test]
+        public void AssertThrows_should_throw_when_no_exception_is_thrown()
+        {
+            Assert.Throws<AssertionException>(() => _assertions.AssertThrows(() => {}));
+        }
+
+        [Test]
+        public void AssertThrows_should_succeed_when_typed_exception_is_thrown()
+        {
+            _assertions.AssertThrows<InvalidOperationException>(() => throw new InvalidOperationException("Test exception"));
+        }
+
+        [Test]
+        public void AssertThrows_should_throw_when_no_typed_exception_is_thrown()
+        {
+            Assert.Throws<AssertionException>(() => _assertions.AssertThrows<InvalidOperationException>(() => {}));
+        }
+
+        [Test]
+        public void AssertThrows_should_throw_when_exception_of_wrong_type_is_thrown()
+        {
+            Assert.Throws<AssertionException>(() => _assertions.AssertThrows<InvalidOperationException>(() => throw new OperationCanceledException("Test exception")));
+        }
+
+        [Test]
+        public async Task AssertThrowsAsync_should_succeed_when_exception_is_thrown()
+        {
+            await _assertions.AssertThrowsAsync(() => throw new Exception("Test exception"));
+        }
+
+        [Test]
+        public void AssertThrowsAsync_should_throw_when_no_exception_is_thrown()
+        {
+            Assert.Throws<AssertionException>(() =>
+            {
+                _assertions.AssertThrowsAsync(() => Task.CompletedTask);
+            });
+        }
+
+        [Test]
+        public async Task AssertThrowsAsync_should_succeed_when_typed_exception_is_thrown()
+        {
+            await _assertions.AssertThrowsAsync<InvalidOperationException>(() => throw new InvalidOperationException("Test exception"));
+        }
+
+        [Test]
+        public void AssertThrowsAsync_should_throw_when_no_typed_exception_is_thrown()
+        {
+            Assert.Throws<AssertionException>(() => _assertions.AssertThrowsAsync<InvalidOperationException>(() => Task.CompletedTask));
+        }
+
+        [Test]
+        public void AssertThrowsAsync_should_throw_when_exception_of_wrong_type_is_thrown()
+        {
+            Assert.Throws<AssertionException>(() => _assertions.AssertThrowsAsync<InvalidOperationException>(() => throw new OperationCanceledException("Test exception")));
         }
     }
 }

--- a/src/Akka.TestKit.NUnit/NUnitAssertions.cs
+++ b/src/Akka.TestKit.NUnit/NUnitAssertions.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Akka.TestKit.NUnit
@@ -38,6 +39,26 @@ namespace Akka.TestKit.NUnit
         public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)
         {
             Assert.That(actual, Is.EqualTo(expected).Using<T>(comparer), NUnitAssertBase.ConvertMessageWithArgs(format, args));
+        }
+
+        public Exception AssertThrows(Action action)
+        {
+            return Assert.Throws<Exception>(() => action());
+        }
+
+        public TException AssertThrows<TException>(Action action) where TException : Exception
+        {
+            return Assert.Throws<TException>(() => action());
+        }
+
+        public Task<Exception> AssertThrowsAsync(Func<Task> action)
+        {
+            return Task.FromResult(Assert.ThrowsAsync<Exception>(() => action()));
+        }
+
+        public Task<TException> AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception
+        {
+            return Task.FromResult(Assert.ThrowsAsync<TException>(() => action()));
         }
 
         /// <remarks>


### PR DESCRIPTION
## Changes

This PR bumps Akka.TestKit to 1.5.64 and implements new methods of the interface ITestKitAssertions

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

- [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).