### PR TITLE
Update RELEASE_NOTES.md for 1.5.67 release

### DIFF
--- a/Directory.Generated.props
+++ b/Directory.Generated.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.59</VersionPrefix>
-    <PackageReleaseNotes>- Bump `Akka.TestKit` to [1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
+    <VersionPrefix>1.5.67</VersionPrefix>
+    <PackageReleaseNotes>- Bump `Akka.TestKit` to [1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+#### 1.5.67 April 28th 2026 ####
+- Bump `Akka.TestKit` to [1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67)
+
+#### 1.5.64 April 8th 2026 ####
+- Bump `Akka.TestKit` to [1.5.64](https://github.com/akkadotnet/akka.net/releases/tag/1.5.64)
+- Add `AssertThrows`, `AssertThrows<TException>`, `AssertThrowsAsync`, and `AssertThrowsAsync<TException>` assertion methods to `NUnitAssertions`
+
+#### 1.5.60 February 10th 2026 ####
+- Bump `Akka.TestKit` to [1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)
+
 #### 1.5.59 January 26th 2025 ####
 - Bump `Akka.TestKit` to [1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
 


### PR DESCRIPTION
## Summary

- Add `1.5.67` release notes entry (Akka.TestKit version bump)
- Backfill missing `1.5.64` entry (new `AssertThrows`/`AssertThrowsAsync` assertion methods)
- Backfill missing `1.5.60` entry (Akka.TestKit version bump)
- Update `Directory.Generated.props` via `build.ps1` to set `VersionPrefix` to `1.5.67`

## Test plan

- [ ] Verify `Directory.Generated.props` has `VersionPrefix` = `1.5.67`
- [ ] Verify `RELEASE_NOTES.md` top entry is `1.5.67` with correct date (April 28th 2026)
- [ ] CI build passes on net8.0 and net462